### PR TITLE
Refactor @GenezioDeploy and @GenezioMethod according to the latest pr…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type GenezioDeployMethodParameters = {
 
 // Decorator that marks that a class should be deployed using genezio.
 export function GenezioDeploy(_dict: GenezioDeployClassParameters = {}) {
-    return (value: Function, _context: any) => {
+    return (value: any, _context: any) => {
         return value; 
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,20 +21,21 @@ export type GenezioDeployMethodParameters = {
 
 // Decorator that marks that a class should be deployed using genezio.
 export function GenezioDeploy(_dict: GenezioDeployClassParameters = {}) {
-    return (_ctor: Function) => {}
+    return (value: Function, _context: any) => {
+        return value; 
+    }
+
 }
 
 // Decorator that marks that a method should be deployed using genezio.
 export function GenezioMethod(_dict: GenezioDeployMethodParameters = {}) {
-    return function (_target: Object, _key: string, descriptor: TypedPropertyDescriptor<any>) {
-        let originalMethod = descriptor.value;
-
-        descriptor.value = function(...args: any[]) {
-            return originalMethod.apply(this, args);
+    return function(value: Function, _context: any) {
+        return function (...args: any[]) {
+            const result = value(args);
+            return result
         };
+    };
 
-        return descriptor;
-    }
 }
 
 export type GenezioHttpRequest  = {


### PR DESCRIPTION
We were using the legacy version of the decorators. Now we refactor `@GenezioDeploy` and `@GenezioMethod` according to the latest proposal.

One advantage is that we won't need the `experimentalDecorators: true` option in tsconfig.